### PR TITLE
added decimalScale of 3 to both perItem tax and total amount tax

### DIFF
--- a/src/renderer/pages/invoices/Form/Dropdowns/TaxDropdown.tsx
+++ b/src/renderer/pages/invoices/Form/Dropdowns/TaxDropdown.tsx
@@ -167,6 +167,7 @@ const TaxDropdownComponent: FC<Props> = ({ isOpen, data, onClose, onOpen, onClic
                 max={100}
                 label={t('invoices.percentage')}
                 value={form.taxRate}
+                decimalScale={3}
                 error={errors.taxRate}
                 helperText={errors.taxRate ? t('common.fieldRequired') : ''}
                 onChange={e => {
@@ -233,6 +234,7 @@ const TaxDropdownComponent: FC<Props> = ({ isOpen, data, onClose, onOpen, onClic
                       <AmountInput
                         required={false}
                         max={100}
+                        decimalScale={3}
                         label={'%'}
                         value={invoiceItem.taxRate}
                         onChange={(e?: number) => {


### PR DESCRIPTION
Closes #111

Tax percentage fields in TaxDropdown only accepted integers due to AmountInput defaulting decimalScale to 0 when no format prop was passed. Added decimalScale={3} to both the invoice-level and per-item tax rate inputs so users can now enter decimal tax rates.

Only this renderer change is needed since the backend stores taxRate as REAL in the db and all tax calculations just multiply the rate directly without any rounding or integer conversion thus decimal values like 9.975 should work correctly (though please verify this on review).

Example of changes using example given in #111

Quebec, the TVQ is 9.975%

Before: entering a tax rate % of 9.975 was not possible only whole integers were allowed.

After: The tax rate field accepts up to 3 decimal places. Entering 9.975 is saved and applied correctly to invoice calculations. Screenshot below 

<img width="1040" height="587" alt="image" src="https://github.com/user-attachments/assets/1c74cd4b-b58b-40e4-9790-dda044f301b2" />